### PR TITLE
Enables source mapping by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Put your changes here...
+- Enabled source mapping by default when in development mode
 
 ## 0.4.1 and below
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ roosevelt-sass
 
 [SASS](http://sass-lang.com/) CSS preprocessor middleware for [Roosevelt MVC web framework](https://github.com/rooseveltframework/roosevelt). See Roosevelt CSS compiler docs for usage.
 
-See the [node-sass](https://github.com/sass/node-sass#options) repo API docs for documentation on available params.
+See the [node-sass](https://github.com/sass/node-sass#options) repo API docs for documentation on available params. By default, source mapping is enabled with `sourceMap: true`, `sourceMapEmbed: true`, and `sourceMapContents: true` in development mode. 
 
 ## Backwards compatibility notes
 

--- a/roosevelt-sass.js
+++ b/roosevelt-sass.js
@@ -21,12 +21,16 @@ module.exports = {
       }
 
       // add the sourceMap param to option if the env is in development
-      if (app.settings.env === 'development') {
+      if (app.settings.env === 'development' && params.sourceMap !== null && params.sourceMap !== undefined) {
         options.sourceMap = params.sourceMap
         options.outFile = params.outFile
         options.sourceMapEmbed = params.sourceMapEmbed
         options.omitSourceMapUrl = params.omitSourceMapUrl
         options.sourceMapRoot = params.sourceMapRoot
+      } else if (app.settings.env === 'development') {
+        options.sourceMap = true
+        options.sourceMapEmbed = true
+        options.sourceMapContents = true
       } else {
         options.sourceMap = undefined
         options.outFile = undefined


### PR DESCRIPTION
Closes #93 
Todo:

- [x] CHANGELOG.md
- [x] README.md
- [x] tests